### PR TITLE
chore(repo): add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ionic-team/stencil


### PR DESCRIPTION
add a codeowners file to ensure that the stencil
team is assigned to review pull requests in this
repository.