### PR TITLE
chore(ci): add lint and format check

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -1,0 +1,25 @@
+name: Lint and Format Stencil Playwright
+
+on:
+  merge_group:
+  workflow_call:
+    # Make this a reusable workflow, no value needed
+    # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+
+jobs:
+  format:
+    name: Check
+    runs-on: 'ubuntu-22.04'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      - name: ESLint
+        run: npm run lint
+
+      - name: Prettier Check
+        run: npm run format.dry-run
+        shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,3 +17,7 @@ jobs:
   build_core:
     name: Build
     uses: ./.github/workflows/build.yml
+
+  lint_and_format:
+    name: Lint and Format
+    uses: ./.github/workflows/lint-and-format.yml

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "build.empty": "rm -rf ./dist && rm -f ./build/build.js",
     "build.types": "tsc --emitDeclarationOnly --outDir ./dist",
     "build.bundle": "tsc ./build/build.ts && node ./build/build.js",
-    "format": "prettier --write \"src/**/*.ts\"",
+    "format": "npm run format.base -- --write",
+    "format.base": "prettier --cache \"src/**/*.ts\"",
+    "format.dry-run": "npm run format.base -- --list-different",
     "lint": "eslint \"src/**/*.ts\""
   },
   "repository": {


### PR DESCRIPTION
this commit adds the ability to run the lint and format checks to the ci pipeline. these checks are called as a separate workflow to break them out from one contiguous pipe, similar to what we do on the stencil core repo

**Do not merge, waiting for parent to land**

**Note: CI will fail until we fix the lint errors**. I don't know if/where/when we're gonna resolve the errors in the initial branch - this might be a bit premature to land