### PR TITLE
chore(ci): add initial testing ci pipeline

### DIFF
--- a/.github/workflows/actions/download-archive/action.yml
+++ b/.github/workflows/actions/download-archive/action.yml
@@ -1,0 +1,20 @@
+name: 'Stencil Playwright Archive Download'
+description: 'downloads and decompresses an archive from a previous job'
+inputs:
+  path:
+    description: 'location to decompress the archive to'
+  filename:
+    description: 'the name of the decompressed artifact'
+  name:
+    description: 'name of the archive to decompress'
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+
+    - name: Extract Archive
+      run: unzip -q -o ${{ inputs.path }}/${{ inputs.filename }} -d ${{ inputs.path }}
+      shell: bash

--- a/.github/workflows/actions/upload-archive/action.yml
+++ b/.github/workflows/actions/upload-archive/action.yml
@@ -1,0 +1,20 @@
+name: 'Stencil Playwright Archive Upload'
+description: 'compresses and uploads an archive to be reused across jobs'
+inputs:
+  paths:
+    description: 'paths to files or directories to archive (recursive)'
+  output:
+    description: 'output file name'
+  name:
+    description: 'name of the archive to upload'
+runs:
+  using: 'composite'
+  steps:
+    - name: Create Archive
+      run: zip -q -r ${{ inputs.output }} ${{ inputs.paths }}
+      shell: bash
+
+    - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.output }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,10 @@ jobs:
       - name: Stencil Playwright Build
         run: npm run build
         shell: bash
+
+      - name: Upload Build Artifacts
+        uses: ./.github/workflows/actions/upload-archive
+        with:
+          name: stencil-playwright
+          output: stencil-playwright-build.zip
+          paths: dist/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_core:
+  build_playwright:
     name: Build
     uses: ./.github/workflows/build.yml
 
   lint_and_format:
     name: Lint and Format
     uses: ./.github/workflows/lint-and-format.yml
+
+  unit_tests:
+    name: Unit Tests
+    needs: [build_playwright]
+    uses: ./.github/workflows/test-unit.yml
+    with:
+      build_name: stencil-playwright

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,0 +1,32 @@
+name: Unit Tests
+
+on:
+  workflow_call:
+    # Make this a reusable workflow, no value needed
+    # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+    inputs:
+      build_name:
+        description: Name for the build, used to resolve the correct build artifact
+        required: true
+        type: string
+
+jobs:
+  unit_test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      - name: Download Build Archive
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: ${{ inputs.build_name }}
+          path: .
+          filename: stencil-playwright-build.zip
+
+      - name: Unit Tests
+        run: npm run test
+        shell: bash

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "format": "npm run format.base -- --write",
     "format.base": "prettier --cache \"src/**/*.ts\"",
     "format.dry-run": "npm run format.base -- --list-different",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "echo Testing 123"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
add an initial testing pipeline to ci. at the time of this writing, the project doesn't have any formal testing infra set up. as a result, we run a stub command defined in `package.json` that just echoes some nonsense to the terminal in the interim.

the pipeline is updated such that the build workflow uploads the build archive for a new test-unit workflow to pull down and run (however, today we're not actually using it, this just puts the plumbing in place).

to accomplish this, new actions for uploading/downloading the archive that match stencil core are added to the project

**Do not merge**. Waiting for parent to land in `main`

**Testing**
Tailed the logs of the ci pipeline, everything appears to pull down and run successfully