### PR TITLE
chore(repo): add automated dev releases

### DIFF
--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -1,0 +1,62 @@
+name: 'Publish to NPM'
+description: 'Publish the package to the NPM registry'
+inputs:
+  version:
+    description: 'The type of version to release.'
+  tag:
+    description: 'The tag to publish to on NPM.'
+  token:
+    description: 'The NPM authentication token required to publish.'
+runs:
+  using: 'composite'
+  steps:
+    # Log the input from GitHub Actions for easy traceability
+    - name: Log Inputs
+      run: |
+        echo "Version: ${{ inputs.version }}"
+        echo "Tag: ${{ inputs.tag }}"
+      shell: bash
+
+    - name: Checkout Code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Get Core Dependencies
+      uses: ./.github/workflows/actions/get-core-dependencies
+
+    - name: Download Build Archive
+      uses: ./.github/workflows/actions/download-archive
+      with:
+        name: stencil-playwright
+        path: .
+        filename: stencil-playwright-build.zip
+
+    # Remove the ZIP file after we've extracted it - we don't want this committed back to the repo
+    - name: Delete The Archive ZIP File
+      run: rm stencil-playwright-build.zip
+      shell: bash
+
+    - name: Bump Version
+      run: npm version --no-git-tag-version ${{ inputs.version }}
+      shell: bash
+
+    # Log the git diff for easy debugging
+    - name: Log Generated Changes
+      run: git --no-pager diff
+      shell: bash
+
+    # Log the git status for easy debugging
+    - name: Log Status
+      run: git status
+      shell: bash
+
+    - name: Prepare NPM Token
+      run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+      shell: bash
+      env:
+        NPM_TOKEN: ${{ inputs.token }}
+
+    # TODO(STENCIL-1206): Add --provenance flag to the command after we've made the repo public
+    # https://github.blog/changelog/2023-07-26-publishing-with-npm-provenance-from-private-source-repositories-is-no-longer-supported/
+    - name: Publish to NPM
+      run: npm publish --tag ${{ inputs.tag }}
+      shell: bash

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,53 @@
+name: 'Dev Release'
+
+on:
+  workflow_dispatch:
+  # Make this a reusable workflow, no value needed
+  # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+
+jobs:
+  build_stencil_playwright:
+    name: Build
+    uses: ./.github/workflows/build.yml
+
+  get_dev_version:
+    name: Get Dev Build Version
+    runs-on: ubuntu-latest
+    outputs:
+      dev-version: ${{ steps.generate-dev-version.outputs.DEV_VERSION }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Generate Dev Version
+        id: generate-dev-version
+        run: |
+          PKG_JSON_VERSION=$(cat package.json | jq -r '.version')
+          GIT_HASH=$(git rev-parse --short HEAD)
+
+          # A unique string to publish Stencil Playwright under
+          # e.g. "2.1.0-dev.1677185104.7c87e34"
+          DEV_VERSION=$PKG_JSON_VERSION-dev.$(date +"%s").$GIT_HASH
+          
+          echo "Using version $DEV_VERSION"
+
+          # store a key/value pair in GITHUB_OUTPUT
+          # e.g. "DEV_VERSION=2.1.0-dev.1677185104.7c87e34"
+          echo "DEV_VERSION=$DEV_VERSION" >> $GITHUB_OUTPUT
+        shell: bash
+
+  release_stencil_playwright:
+    name: Publish Dev Build
+    needs: [build_stencil_playwright, get_dev_version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: ./.github/workflows/actions/publish-npm
+        with:
+          tag: dev
+          version: ${{ needs.get_dev_version.outputs.dev-version }}
+          token: ${{ secrets.NPM_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,34 @@
+# Releasing Stencil Playwright
+
+## Development Releases
+
+Development Releases (or "Dev Releases", "Dev Builds") are installable instances of Stencil Playwright that are:
+- Published to the npm registry for distribution within and outside the Stencil team
+- Built using the same infrastructure as production releases, with less safety checks
+- Used to verify a fix or change to the project prior to a production release
+
+### How to Publish
+
+Only members of the Stencil team may create dev builds of Stencil Playwright.
+To publish the package:
+1. Navigate to the [Stencil Playwright Dev Release GitHub Action](https://github.com/ionic-team/stencil-playwright/actions/workflows/release-dev.yml) in your browser.
+2. Select the 'Run Workflow' dropdown on the right hand side of the page
+3. The dropdown will ask you for a branch name to publish from. Any branch may be used here.
+4. Select 'Run Workflow'
+5. Allow the workflow to run. Upon completion, the output of the 'publish-npm' action will report the published version string.
+
+Following a successful run of the workflow, the package can be installed from the npm registry like any other package.
+
+### Publish Format
+
+Dev Builds are published to the NPM registry under the `@stencil/playwright` scope.
+Unlike production builds, dev builds use a specially formatted version string to express its origins.
+Dev builds follow the format `BASE_VERSION-dev.EPOCH_DATE.SHA`, where:
+- `BASE_VERSION` is the latest production release changes to the build were based off of
+- `EPOCH_DATE` is the number of seconds since January 1st, 1970 in UTC
+- `SHA` is the git short SHA of the commit used in the release
+
+As an example: `2.1.0-dev.1677185104.7c87e34` was built:
+- With v2.1.0 as the latest production build at the time of the dev build
+- On Fri, 26 Jan 2024 13:48:17 UTC
+- With the commit `7c87e34`


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil-playwright/blob/main/CONTRIBUTING.md -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We don't have any support for automated dev builds.

While this may seem unneeded for a new project, it's a great way to allow us to get quick feedback from the community, and build towards automated production deployments

GitHub Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

add the ability to publish a dev build of the project to the npm registry. we do so by adding a new workflow that can be manually kicked off, `release-dev`. as the name implies, it creates a dev build (running the most basic/essential parts of the build pipeline) and invokes a publish to npm

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

In https://github.com/ionic-team/stencil-playwright/pull/14/commits/7fde79052a6fdafdf8e2420da8a3782054d8560b, I had a push event trigger enabled such that when I pushed this branch to GitHub, a dev build would get triggered. I considered this to be safe because:
1. It built off the same workflow/steps as the create-stencil cli, which has dev releases
2. I tested this _without_ publishes enabled at first (commented out)
3. I figured worst case, since I verified the tag and version number, I'd push a bad dev release to npm 
4. [<GH_ACTION_RUN> ](https://github.com/ionic-team/stencil-playwright/actions/runs/8281791216/job/22661126739) shows a successful publish to the npm registry
```
Run npm publish --tag dev
npm notice 
npm notice 📦  @stencil/playwright@0.1.0-dev.1710423894.3547fcc
npm notice === Tarball Contents === 
npm notice 1.4kB   LICENSE.md                                            
npm notice 22B     README.md                                             
npm notice 1.4kB   dist/create-config.d.ts                               
npm notice 216.1kB dist/index.cjs                                        
npm notice 482.9kB dist/index.cjs.map                                    
npm notice 234B    dist/index.d.ts                                       
npm notice 214.8kB dist/index.js                                         
npm notice 482.4kB dist/index.js.map                                     
npm notice 308B    dist/load-config-meta.d.ts                            
npm notice 751B    dist/matchers/index.d.ts                              
npm notice 191B    dist/matchers/to-have-first-received-event-detail.d.ts
npm notice 204B    dist/matchers/to-have-nth-received-event-detail.d.ts  
npm notice 191B    dist/matchers/to-have-received-event-detail.d.ts      
npm notice 187B    dist/matchers/to-have-received-event-times.d.ts       
npm notice 167B    dist/matchers/to-have-received-event.d.ts             
npm notice 1.7kB   dist/page/event-spy.d.ts                              
npm notice 755B    dist/page/utils/goto.d.ts                             
npm notice 150B    dist/page/utils/index.d.ts                            
npm notice 848B    dist/page/utils/locator.d.ts                          
npm notice 707B    dist/page/utils/set-content.d.ts                      
npm notice 193B    dist/page/utils/spy-on-event.d.ts                     
npm notice 588B    dist/page/utils/wait-for-changes.d.ts                 
npm notice 5.5kB   dist/playwright-declarations.d.ts                     
npm notice 446B    dist/playwright-page.d.ts                             
npm notice 132B    dist/process-constants.d.ts                           
npm notice 630B    dist/test-expect.d.ts                                 
npm notice 2.3kB   package.json                                          
npm notice === Tarball Details === 
npm notice name:          @stencil/playwright                                
npm notice version:       0.1.0-dev.1710423894.3547fcc                       
npm notice filename:      stencil-playwright-0.1.0-dev.1710423894.3547fcc.tgz
npm notice package size:  331.5 kB                                           
npm notice unpacked size: 1.4 MB                                             
npm notice shasum:        ef05b57cc4e4aab08737b0da68a32bf88c6c5948           
npm notice integrity:     sha512-rdW7jBVFf7/47[...]5Bb4PF7vTd7+Q==           
npm notice total files:   27                                                 
npm notice 
```
![Screenshot 2024-03-14 at 9 55 40 AM](https://github.com/ionic-team/stencil-playwright/assets/1930213/c4426f81-3f02-43d4-8b93-9ffb63c0184b)

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
