### PR TITLE
fix(create-config): use Playwright's `defineConfig` API

### DIFF
--- a/src/create-config.ts
+++ b/src/create-config.ts
@@ -1,4 +1,4 @@
-import { PlaywrightTestConfig } from '@playwright/test';
+import { defineConfig, PlaywrightTestConfig } from '@playwright/test';
 
 import { loadConfigMeta } from './load-config-meta';
 import { ProcessConstants } from './process-constants';
@@ -48,7 +48,7 @@ export const createStencilPlaywrightConfig = async (
   delete playwrightOverrides.webServerCommand;
   delete playwrightOverrides.webServerTimeout;
 
-  return {
+  return defineConfig({
     testMatch: '*.e2e.ts',
     use: {
       baseURL,
@@ -61,5 +61,5 @@ export const createStencilPlaywrightConfig = async (
       timeout: overrides?.webServerTimeout ?? undefined,
     },
     ...playwrightOverrides,
-  };
+  });
 };


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil-playwright/blob/main/CONTRIBUTING.md -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Uses Playwright's `defineConfig` API in our `createStencilPlaywrightConfig()` utility method. Doesn't alter behavior, but adds some additional validation on Playwright's end for the supplied values

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
