### PR TITLE
chore(repo): create initial production release workflow

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -1,0 +1,49 @@
+name: 'Stencil Playwright Production Release'
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: false
+        default: latest
+        type: choice
+        description: Which npm tag should this be published to?
+        options:
+          - latest
+          - dev
+
+
+jobs:
+  build_stencil_playwright:
+    name: Build
+    uses: ./.github/workflows/build.yml
+
+  release_stencil_playwright_production_build:
+    name: Publish Stencil Playwright (Production)
+    needs: [ build_stencil_playwright ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      # Log the input from GitHub Actions for easy traceability
+      - name: Log GitHub Workflow UI Input
+        run: |
+          echo "Tag: ${{ inputs.tag }}"
+        shell: bash
+
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: 'main'
+
+      - name: Get the Version String
+        id: version_retrieval
+        run: |
+          VERSION_STR=$(jq '.version' package.json | sed s/\"//g)
+          echo "VERSION_STR=$VERSION_STR" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Print Version String
+        run: |
+          echo Version: ${{ steps.version_retrieval.outputs.VERSION_STR }}
+        shell: bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,11 +27,11 @@ To publish the package:
    Only one approval is required for pull requests that only include the version bump/prerelease commit.
 1. Once approved, add it to the merge queue.
 1. ⚠️ Wait for the pull request to land before continuing to the next step. ⚠️
-1. Navigate to the [Stencil Playwright Prod Release GitHub Action](https://github.com/ionic-team/stencil-playwright/actions/workflows/release-prod.yml) in your browser.
+1. Navigate to the [Stencil Playwright Prod Release GitHub Action](https://github.com/ionic-team/stencil-playwright/actions/workflows/release-production.yml) in your browser.
 1. Select the 'Run Workflow' dropdown on the right hand side of the page
-1. The dropdown will ask you for a version type to publish.
-   Stencil Playwright follows semantic versioning.
-   Review the changes on `main` and select the most appropriate release type.
+1. The dropdown will ask you which tag to publish the project under.
+   For production releases, select 'latest'.
+   For testing the workflow itself, select 'dev'.
 1. Select 'Run Workflow'
 1. Allow the workflow to run. Upon completion, the output of the 'publish-npm' action will report the published version string.
 1. Navigate to the project's [Releases Page](https://github.com/ionic-team/stencil-playwright/releases)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil-playwright/blob/main/CONTRIBUTING.md -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

we don't have production releases for this project yet, this pr gets us one step closer to that

GitHub Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

note: this is an initial pr that does not enable production publishes.
read on to understand what this commit does and does not do.

add the basis of a produciton release github action workflow. this
workflow allows a use to provide a `tag` for npm to publish a new
version of package under.

this workflow builds the package, pulls the current version string out
of `package.json` (it assumes that the `create-production-pr` workflow
has already run), and prints it to the console.

this workflow does not yet invoke the publish-npm action. the reason
for this is safety/preventing unwanted publishes while this workflow is
created. since `releae-production` has not landed in the codebase,
attempting to run `publish-npm` would pull the action from `main`. this
is undesirable, as there are a handful of changes/modifications we
wish to make to the workflow to test `release-produciton` with regard
to tag publishes to github, not bumping the version in npm, etc.

instead, we opt to 'stub' this workflow for now to land it, then we can
safely iterate on it using a non-`push` target

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

Internal release docs have been updated in this PR. While the full publish pipeline is not is place, please review to make sure they make sense

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
As of 1210fddaef4afd682fdbcd996533736845061342, I was able to push to this branch as have this initial workflow run [(logs)](https://github.com/ionic-team/stencil-playwright/actions/runs/8328880251/job/22789934980)

We can correctly determine the version number:
![Screenshot 2024-03-18 at 11 14 49 AM](https://github.com/ionic-team/stencil-playwright/assets/1930213/48f26d9f-54d1-436e-9624-ef41ffe4997a)

Note - the "log github workflow ui input" step will report an empty string, because I ran this with a `push` target, which doesn't have any "input" so to speak

## Other information

**Depends On**: #20 - I plan on landing that in `main` before landing this
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
