### PR TITLE
chore(repo): automate prod releases 

### DIFF
--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -36,7 +36,11 @@ runs:
       shell: bash
 
     - name: Bump Version
-      run: npm version --no-git-tag-version ${{ inputs.version }}
+      # --allow-same-version is useful for cases when performing a production release, where we expect the version to
+      # have been bumped by running the Production PR Creation workflow first.
+      #
+      # TODO(STENCIL-1221): Push git tags to GitHub, only on Prod releases
+      run: npm version --no-git-tag-version ${{ inputs.version }} --allow-same-version
       shell: bash
 
     # Log the git diff for easy debugging

--- a/.github/workflows/create-production-pr.yml
+++ b/.github/workflows/create-production-pr.yml
@@ -1,4 +1,4 @@
-name: 'Stencil Playwright Production Release PR Creation'
+name: 'Production Release PR Creation'
 
 on:
   workflow_dispatch:
@@ -17,13 +17,8 @@ on:
           - major
 
 jobs:
-  build_stencil_playwright:
-    name: Build
-    uses: ./.github/workflows/build.yml
-
   create_stencil_playwright_release_pr:
     name: Generate Stencil Playwright Release PR
-    needs: [build_stencil_playwright]
     runs-on: ubuntu-latest
     steps:
       # Log the input from GitHub Actions for easy traceability
@@ -37,16 +32,6 @@ jobs:
 
       - name: Get Core Dependencies
         uses: ./.github/workflows/actions/get-core-dependencies
-
-      - name: Download Build Archive
-        uses: ./.github/workflows/actions/download-archive
-        with:
-          name: stencil-playwright
-          path: .
-          filename: stencil-playwright-build.zip
-
-      - name: Delete the Zip File
-        run: rm stencil-playwright-build.zip
 
       - name: Bump the Version
         run: npm version ${{ inputs.version }} --no-git-tag

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -21,9 +21,6 @@ jobs:
     name: Publish Stencil Playwright (Production)
     needs: [ build_stencil_playwright ]
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
     steps:
       # Log the input from GitHub Actions for easy traceability
       - name: Log GitHub Workflow UI Input
@@ -47,3 +44,9 @@ jobs:
         run: |
           echo Version: ${{ steps.version_retrieval.outputs.VERSION_STR }}
         shell: bash
+
+      - uses: ./.github/workflows/actions/publish-npm
+        with:
+          tag: ${{ inputs.tag }}
+          version: ${{ steps.version_retrieval.outputs.VERSION_STR }}
+          token: ${{ secrets.NPM_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ To publish the package:
 
 1. Call a `code-freeze` on this project in the Stencil team channel
 1. Check that [the Merge Queue](https://github.com/ionic-team/stencil-playwright/queue/) is empty (nothing is queued for merge).
-1. Navigate to the [Create Production Release PR GitHub Action](https://github.com/ionic-team/stencil-playwright/actions/workflows/create-production-pr.yml) in your browser.
+1. Navigate to the [Production Release PR Creation GitHub Action](https://github.com/ionic-team/stencil-playwright/actions/workflows/create-production-pr.yml) in your browser.
 1. Select the 'Run Workflow' dropdown on the right hand side of the page
 1. The dropdown will ask you which branch to use the workflow from and which version should be published.
      1. Choose 'main' for the branch name.
@@ -29,13 +29,17 @@ To publish the package:
 1. ⚠️ Wait for the pull request to land before continuing to the next step. ⚠️
 1. Navigate to the [Stencil Playwright Prod Release GitHub Action](https://github.com/ionic-team/stencil-playwright/actions/workflows/release-production.yml) in your browser.
 1. Select the 'Run Workflow' dropdown on the right hand side of the page
-1. The dropdown will ask you which tag to publish the project under.
-   For production releases, select 'latest'.
-   For testing the workflow itself, select 'dev'.
+1. The dropdown will ask you which git branch & tag to publish the project under.
+     1. Use the `main` branch, unless you're testing changes to the pipeline itself.
+        Note: Using a non-`main` branch does not necessarily mean changes to actions in non-`main` will be pulled!
+        Always use caution when making changes to actions this workflow uses.
+     2. For production releases, select 'latest'.
+        For testing the workflow itself, select 'dev'.
 1. Select 'Run Workflow'
 1. Allow the workflow to run. Upon completion, the output of the 'publish-npm' action will report the published version string.
 1. Navigate to the project's [Releases Page](https://github.com/ionic-team/stencil-playwright/releases)
 1. Select 'Draft a new release'
+1. You will need to create git tag for the version that was just published.
 1. Select the tag of the version you just created in the 'Choose a tag' dropdown
 1. Click "Generate release notes"
 1. Ensure this is the latest release


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil-playwright/blob/main/CONTRIBUTING.md -->

## What is the current behavior?

We'd like automated prod releases to work! They're not quite there yet, but this pr should fix that.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit shortens the pr creation workflow name. previously, the pr
creation workflow and production release names were similarly named,
leading to the github actions ui to display one atop the other _and_
truncated, making it likely we'd pick the wrong workflow, like so:
```
Stencil Playwright Production Release
Stencil Playwright Production Release Pr ...
```

Unused permissions have been removed from the `release-production`
workflow, as we're currently not writing  back to git/github. These
should have been removed in https://github.com/ionic-team/stencil-playwright/pull/22.

An unnecessary build step has been removed from the create-production-pr
workflow, as this is handled elsewhere/is not used in this workflow.

`--allow-same-version` has been added when we bump the npm version as
a part of publishing to npm. this allows us to bump the version during
the prod pr creation workflow, land that change, then run this workflow
from the head of `main`.
## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

`RELEASE.md` has been updated.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

As of https://github.com/ionic-team/stencil-playwright/pull/27/commits/3eba781a0d59cd54bf68abda676b212ce1b30894, I kicked off a run of the production release workflow. Because `publish-npm` gets pulled from `main`, I fed it the following values:
```
tag: dev
version: 0.0.1-dev
token: ${{ secrets.NPM_TOKEN }}
```

The output of the action itself can be found [here](https://github.com/ionic-team/stencil-playwright/actions/runs/8360756227/job/22887158218), but we do publish correctly with that input:

> npm notice 📦  @stencil/playwright@0.0.1-dev

Looking at NPM, we can see that it successfully publishes - https://www.npmjs.com/package/@stencil/playwright/v/0.0.1-dev

---

The only thing I couldn't test well is the `--allow-same-version`. The reason is testing this flag in the context of the workflow itself requires us to publish v0.1.0, which I was hesitant to do.

However, I did run the command locally to ensure there weren't any typos, flag collisions, etc.:
```bash
$ npm version --no-git-tag-version 0.1.0 --allow-same-version
v0.1.0
``` 

---

The changes in https://github.com/ionic-team/stencil-playwright/pull/27/commits/ea1f2c9667c222620934fa932577a8253af86149 aren't tested, as they'd kick off an actual prod release. We can see in https://github.com/ionic-team/stencil-playwright/actions/runs/8360756227/job/22887158218 the version string is correctly pulled from `package.json`, and the input tag is also formatted correctly. Everything _should_ work here, just calling out that tiny bit of risk
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

This does not create/publish git tags, as we need to determine how we want to do that for prod releases only. It's certainly doable, but there's also the question of how long we want to use this workflow/if another piece of tooling could help us here. 
<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
