### PR TITLE
chore(repo): add --provenance to publishes

### DIFF
--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -59,8 +59,6 @@ runs:
       env:
         NPM_TOKEN: ${{ inputs.token }}
 
-    # TODO(STENCIL-1206): Add --provenance flag to the command after we've made the repo public
-    # https://github.blog/changelog/2023-07-26-publishing-with-npm-provenance-from-private-source-repositories-is-no-longer-supported/
     - name: Publish to NPM
-      run: npm publish --tag ${{ inputs.tag }}
+      run: npm publish --tag ${{ inputs.tag }} --provenance
       shell: bash


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil-playwright/blob/main/CONTRIBUTING.md -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit re-adds package provenance to the publish-npm action. we previously removed this while the repo was private (as --provenance is not supported for private repos). once the repo is public again, we'd like all packages to have provenance enabled.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->
N/A
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I kicked off a manual dev build of this https://github.com/ionic-team/stencil-playwright/actions/runs/8424456349/job/23068375701.

The output of that build run in `@stencil/playwright@0.1.0-dev.1711388093.d961d14`

The dev build was published with provenance - https://www.npmjs.com/package/@stencil/playwright/v/0.1.0-dev.1711388093.d961d14#provenance
![Screenshot 2024-03-25 at 1 39 41 PM](https://github.com/ionic-team/stencil-playwright/assets/1930213/907000eb-2bc0-4af1-9216-f3dfe3ab2777)



## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

STENCIL-1206