### PR TITLE
chore(release): provide permissions for prod provenance

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -21,6 +21,9 @@ jobs:
     name: Publish Stencil Playwright (Production)
     needs: [ build_stencil_playwright ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       # Log the input from GitHub Actions for easy traceability
       - name: Log GitHub Workflow UI Input


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil-playwright/blob/main/CONTRIBUTING.md -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
prior to this commit, we'd get an error trying to publish to npm using the `latest` tag with the following error:
```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access
npm ERR! code EUSAGE
npm ERR! Provenance generation in GitHub Actions requires “write” access to the “id-token” permission
npm ERR! A complete log of this run can be found in: /home/runner/.npm/_logs/2024-03-25T20_09_08_269Z-debug-0.log
```

this ought to fix the issue, using the same permissions that we use in stencil core today

## Documentation
N/A
<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing
Unable to test without publishing to NPM under the `latest` tag, I'm afraid
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
