### PR TITLE
fix(adapter): pipe dev server output to console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
       },
       "peerDependencies": {
         "@playwright/test": ">=1.41.2",
-        "@stencil/core": "^4.13.0"
+        "@stencil/core": ">=4.13.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/src/create-config.ts
+++ b/src/create-config.ts
@@ -59,6 +59,9 @@ export const createStencilPlaywrightConfig = async (
       reuseExistingServer: !!!process.env.CI,
       // Max time to wait for dev server to start before aborting, defaults to 60000 (60 seconds)
       timeout: overrides?.webServerTimeout ?? undefined,
+      // Pipe the dev server output to the console
+      // Gives visibility to the developer if the dev server fails to start
+      stdout: 'pipe',
     },
     ...playwrightOverrides,
   };

--- a/src/test/create-config.spec.ts
+++ b/src/test/create-config.spec.ts
@@ -24,6 +24,7 @@ describe('createStencilPlaywrightConfig', () => {
         url: 'http://localhost:3333/ping',
         reuseExistingServer: !process.env.CI,
         timeout: undefined,
+        stdout: 'pipe',
       },
     });
   });
@@ -45,6 +46,7 @@ describe('createStencilPlaywrightConfig', () => {
         url: 'http://localhost:3333/ping',
         reuseExistingServer: !process.env.CI,
         timeout: undefined,
+        stdout: 'pipe',
       },
     });
   });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil-playwright/blob/main/CONTRIBUTING.md -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the Playwright process doesn't relay any output from the dev server to the console. This can cause confusion for users if there is a build error in the Stencil project since nothing would be logged in the console and the process would appear to hang until the timeout is reached.

GitHub Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

This commit updates the default `webServer` configuration in the Playwright config to pipe the `stdout` output from the dev server through to the Playwright process. 

Unfortunately, AFAICT there isn't a way to terminate the process when this happens. Playwright continuously polls the url until either it: returns a valid status code (200, 300, 400, etc.) or the process timeout is reached. Returning a 500 does not end the process and even returning a code like a 400 will allow tests to execute.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I confirmed that the dev server output is visible from the Playwright process now.

Also tested various cases trying to get the process to terminate, but was unsuccessful.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
