### PR TITLE
fix(adapter): update default command used for `webServer` process

### DIFF
--- a/src/create-config.ts
+++ b/src/create-config.ts
@@ -54,7 +54,7 @@ export const createStencilPlaywrightConfig = async (
       baseURL,
     },
     webServer: {
-      command: overrides?.webServerCommand ?? 'npm start -- --no-open',
+      command: overrides?.webServerCommand ?? 'stencil build --dev --watch --serve --no-open',
       url: webServerUrl,
       reuseExistingServer: !!!process.env.CI,
       // Max time to wait for dev server to start before aborting, defaults to 60000 (60 seconds)

--- a/src/test/create-config.spec.ts
+++ b/src/test/create-config.spec.ts
@@ -20,7 +20,7 @@ describe('createStencilPlaywrightConfig', () => {
         baseURL: 'http://localhost:3333',
       },
       webServer: {
-        command: 'npm start -- --no-open',
+        command: 'stencil build --dev --watch --serve --no-open',
         url: 'http://localhost:3333/ping',
         reuseExistingServer: !process.env.CI,
         timeout: undefined,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil-playwright/blob/main/CONTRIBUTING.md -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The default config assumes there is a `npm start` script in the project's `package.json`

GitHub Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The default config will now explicitly call the Stencil CLI build command with options to spin-up the dev server

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Updated automated tests and confirmed tests still execute in a Stencil starter project

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
