### PR TITLE
feat(adapter): rename config helper to `createConfig`

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,0 +1,12 @@
+# Breaking Changes
+
+This is a list of all breaking changes introduced in the Stencil Playwright adapter. This document is broken into two sections:
+
+1. Breaking changes introduced in experimental versions (i.e. pre-1.0)
+2. Breaking changes introduced in major releases
+
+## Experimental Releases
+
+### v0.2.0
+
+- `createStencilPlaywrightConfig` renamed to `createConfig`

--- a/README.md
+++ b/README.md
@@ -31,26 +31,26 @@ For full documentation, please see the [Playwright testing docs on the official 
    // playwright.config.ts
 
    import { expect } from '@playwright/test';
-   import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+   import { matchers, createConfig } from '@stencil/playwright';
 
    expect.extend(matchers);
 
-   export default createStencilPlaywrightConfig();
+   export default createConfig();
    ```
 
 1. At this point, any tests can be executed using `npx playwright test` (or by updating the project's test command in the `package.json`). By default, Playwright's test matcher
    is configured to run all tests matching the pattern `*.e2e.ts`. This can be changed by overriding the default matcher using the
-   [`createStencilPlaywrightConfig()` function](#createstencilplaywrightconfigoverrides-createstencilplaywrightconfigoptions-promiseplaywrighttestconfig):
+   [`createConfig()` function](#createconfigoverrides-createstencilplaywrightconfigoptions-promiseplaywrighttestconfig):
 
    ```ts
    // playwright.config.ts
 
    import { expect } from '@playwright/test';
-   import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+   import { matchers, createConfig } from '@stencil/playwright';
 
    expect.extend(matchers);
 
-   export default createStencilPlaywrightConfig({
+   export default createConfig({
      // Change which test files Playwright will execute
      testMatch: '*.spec.ts',
      // Any other Playwright config option can also be overridden
@@ -122,7 +122,7 @@ test.describe('my-component', () => {
 
 ## API
 
-### `createStencilPlaywrightConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
+### `createConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
 
 Returns a [Playwright test configuration](https://playwright.dev/docs/test-configuration#introduction).
 
@@ -136,11 +136,11 @@ as some options to override specific values in the config options related to the
 // playwright.config.ts
 
 import { expect } from '@playwright/test';
-import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+import { matchers, createConfig } from '@stencil/playwright';
 
 expect.extend(matchers);
 
-export default createStencilPlaywrightConfig({
+export default createConfig({
   // Change which test files Playwright will execute
   testMatch: '*.spec.ts',
 

--- a/src/create-config.ts
+++ b/src/create-config.ts
@@ -31,9 +31,7 @@ export type CreateStencilPlaywrightConfigOptions = Partial<PlaywrightTestConfig>
  * @param overrides Values to override in the default config. Any Playwright config option can be overridden.
  * @returns A {@link PlaywrightTestConfig} object
  */
-export const createStencilPlaywrightConfig = async (
-  overrides?: CreateStencilPlaywrightConfigOptions,
-): Promise<PlaywrightTestConfig> => {
+export const createConfig = async (overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig> => {
   const { webServerUrl, baseURL, stencilEntryPath, stencilNamespace } = await loadConfigMeta();
 
   // Set the Stencil namespace and entry path as environment variables so we can use them when constructing

--- a/src/playwright-page.ts
+++ b/src/playwright-page.ts
@@ -32,7 +32,7 @@ type CustomFixtures = {
  */
 async function extendPageFixture(page: E2EPage) {
   // Make sure the Stencil namespace and entry path are set on the process so we can use them in the `setContent` tests.
-  // These wouldn't be set if the user didn't setup the Playwright config with the `createStencilPlaywrightConfig()` helper.
+  // These wouldn't be set if the user didn't setup the Playwright config with the `createConfig()` helper.
   if (!process.env[ProcessConstants.STENCIL_NAMESPACE] || !process.env[ProcessConstants.STENCIL_ENTRY_PATH]) {
     const { stencilNamespace, stencilEntryPath } = await loadConfigMeta();
 

--- a/src/test/create-config.spec.ts
+++ b/src/test/create-config.spec.ts
@@ -1,4 +1,4 @@
-import { createStencilPlaywrightConfig } from '../create-config';
+import { createConfig } from '../create-config';
 
 // Mock the loadConfigMeta function to just return the default values
 jest.mock('../load-config-meta', () => ({
@@ -10,9 +10,9 @@ jest.mock('../load-config-meta', () => ({
   }),
 }));
 
-describe('createStencilPlaywrightConfig', () => {
+describe('createConfig', () => {
   it('should create a default config', async () => {
-    const config = await createStencilPlaywrightConfig();
+    const config = await createConfig();
 
     expect(config).toEqual({
       testMatch: '*.e2e.ts',
@@ -29,7 +29,7 @@ describe('createStencilPlaywrightConfig', () => {
   });
 
   it('should override the default config', async () => {
-    const config = await createStencilPlaywrightConfig({
+    const config = await createConfig({
       webServerCommand: 'npm start -- --no-open --port 4444',
       testDir: 'tests/e2e',
     });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil-playwright/blob/main/CONTRIBUTING.md -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Helper is currently names `createStencilPlaywrightConfig` which is a bit wordy

GitHub Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Renames the helper to `createConfig`. The util is already in context/scope of the adapter package, so don't need to worry about confusion on its purpose. Developers can alias the import if they desire.

## Documentation

https://github.com/ionic-team/stencil-site/pull/1398

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

Technically, it would be, but this is a pre-1.0 experimental package.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Updated automated tests and confirmed tests execute correctly in a Stencil component starter project

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
