### PR TITLE
fix(goto): preserve search parameters in URL

### DIFF
--- a/src/page/utils/goto.ts
+++ b/src/page/utils/goto.ts
@@ -16,7 +16,7 @@ export const goto = async (page: Page, url: string, originalFn: typeof page.goto
       // They tested this number and found it to be a reliable timeout for the Stencil components to be hydrated.
       timeout: 4750,
     }),
-    originalFn(url.split('?')[0], options),
+    originalFn(url, options),
   ]);
 
   return result[1];


### PR DESCRIPTION
## What is the current behavior?

It is not possible to navigate to a URL including search parameters because they are stripped by the `goto` override.

Therefor, this test fails:

```js
import { expect } from '@playwright/test';
import { test } from '@stencil/playwright';

test('Playwright', async ({ page }) => {
  const url = 'https://playwright.dev/?key=val';
  await page.goto(url);

  expect(page.url()).toBe(url); // ❌
});
```

There is no obvious reasons for removing the search parameters from the URL in the `goto` method.

GitHub Issue Number:  #45

## What is the new behavior?

Search parameters in the URL are preserved.

## Does this introduce a breaking change?

I would like to say no, but potentially (?)

We should not rely on `goto` stripping the parameters but it's possible someone could have write tests expecting this behavior.

## Testing

I made sure the above test works locally but it does not seem that we have unit test for these "helpers"
